### PR TITLE
Improve deployment experience

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,22 +19,6 @@ locals {
   lambda_env = merge(var.lambda_env, local.eshgham_env, local.github_env)
 }
 
-check "email_notification_inputs" {
-  assert {
-    condition = (
-      !local.enable_email_notification
-      || (
-        length(var.email_fifo_queue_name) > 0
-        && length(local.email_subject_template_file) > 0
-        && length(local.email_text_template_file) > 0
-        && length(local.email_html_template_file) > 0
-        && length(var.email_sender) > 0
-      )
-    )
-    error_message = "When email_recipients is non-empty, email_fifo_queue_name and email_sender must be set. Template files default to module templates unless explicitly overridden."
-  }
-}
-
 provider "aws" {
   region = var.aws_region
 }

--- a/main.tf
+++ b/main.tf
@@ -10,13 +10,20 @@ locals {
   email_subject_template_file         = length(var.email_subject_template_file) > 0 ? var.email_subject_template_file : local.default_email_subject_template_file
   email_text_template_file            = length(var.email_text_template_file) > 0 ? var.email_text_template_file : local.default_email_text_template_file
   email_html_template_file            = length(var.email_html_template_file) > 0 ? var.email_html_template_file : local.default_email_html_template_file
-  eshgham_env = length(var.eshgham_config_file) > 0 ? {
+  eshgham_env = {
     ESHGHAM_WORKFLOWS_YAML = file(var.eshgham_config_file)
-  } : {}
+  }
   github_env = {
     GITHUB_TOKEN = var.github_token
   }
   lambda_env = merge(var.lambda_env, local.eshgham_env, local.github_env)
+}
+
+check "email_notification_sender_required" {
+  assert {
+    condition     = !local.enable_email_notification || length(trimspace(var.email_sender)) > 0
+    error_message = "email_sender must be non-empty when email_recipients is non-empty."
+  }
 }
 
 provider "aws" {

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,18 @@
 locals {
   tags = merge({ managed_by = "eshgham-cron" }, var.tags)
   enable_email_notification = length(var.email_recipients) > 0
+  default_email_subject_template_file = "${path.module}/templates/email-subject.txt"
+  default_email_text_template_file    = "${path.module}/templates/email-body.txt"
+  default_email_html_template_file    = "${path.module}/templates/email-body.html"
+  email_subject_template_file         = length(var.email_subject_template_file) > 0 ? var.email_subject_template_file : local.default_email_subject_template_file
+  email_text_template_file            = length(var.email_text_template_file) > 0 ? var.email_text_template_file : local.default_email_text_template_file
+  email_html_template_file            = length(var.email_html_template_file) > 0 ? var.email_html_template_file : local.default_email_html_template_file
   eshgham_env = length(var.eshgham_config_file) > 0 ? {
     ESHGHAM_WORKFLOWS_YAML = file(var.eshgham_config_file)
   } : {}
-  github_env = length(var.github_token) > 0 ? {
+  github_env = {
     GITHUB_TOKEN = var.github_token
-  } : {}
+  }
   lambda_env = merge(var.lambda_env, local.eshgham_env, local.github_env)
 }
 
@@ -16,13 +22,13 @@ check "email_notification_inputs" {
       !local.enable_email_notification
       || (
         length(var.email_fifo_queue_name) > 0
-        && length(var.email_subject_template_file) > 0
-        && length(var.email_text_template_file) > 0
-        && length(var.email_html_template_file) > 0
+        && length(local.email_subject_template_file) > 0
+        && length(local.email_text_template_file) > 0
+        && length(local.email_html_template_file) > 0
         && length(var.email_sender) > 0
       )
     )
-    error_message = "When email_recipients is non-empty, email_fifo_queue_name, email_subject_template_file, email_text_template_file, email_html_template_file, and email_sender must be set."
+    error_message = "When email_recipients is non-empty, email_fifo_queue_name and email_sender must be set. Template files default to module templates unless explicitly overridden."
   }
 }
 
@@ -86,9 +92,9 @@ module "email_notification" {
   lambda_image_uri  = module.notification_image_republish.lambda_image_uri
   lambda_name       = var.email_lambda_name
 
-  subject_template_file = var.email_subject_template_file
-  text_template_file    = var.email_text_template_file
-  html_template_file    = var.email_html_template_file
+  subject_template_file = local.email_subject_template_file
+  text_template_file    = local.email_text_template_file
+  html_template_file    = local.email_html_template_file
   sender                = var.email_sender
   recipients            = var.email_recipients
   reply_to              = var.email_reply_to
@@ -108,7 +114,7 @@ module "print_notification" {
   result_types     = var.email_result_types
   fifo_queue_name  = "${trimsuffix(var.email_fifo_queue_name, ".fifo")}-print.fifo"
   lambda_image_uri = module.notification_image_republish.lambda_image_uri
-  template_file    = var.email_text_template_file
+  template_file    = local.email_text_template_file
 
   timeout     = var.email_timeout
   memory_size = var.email_memory_size

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,9 @@
 locals {
-  tags = merge({ managed_by = "eshgham-cron" }, var.tags)
-  enable_email_notification = length(var.email_recipients) > 0
+  tags                                = merge({ managed_by = "eshgham-cron" }, var.tags)
+  enable_email_notification           = length(var.email_recipients) > 0
+  notification_image_uri_override     = var.notification_image_uri_override == null ? null : trimspace(var.notification_image_uri_override)
+  use_notification_image_override     = local.notification_image_uri_override != null
+  notification_lambda_image_uri       = local.use_notification_image_override ? local.notification_image_uri_override : module.notification_image_republish[0].lambda_image_uri
   default_email_subject_template_file = "${path.module}/templates/email-subject.txt"
   default_email_text_template_file    = "${path.module}/templates/email-body.txt"
   default_email_html_template_file    = "${path.module}/templates/email-body.html"
@@ -50,6 +53,7 @@ module "lambda_image_republish" {
 }
 
 module "notification_image_republish" {
+  count  = local.use_notification_image_override ? 0 : 1
   source = "git::https://github.com/omsf/lambdacron.git//modules/lambda-image-republish"
 
   source_lambda_repo = var.notification_public_repo_url
@@ -65,18 +69,18 @@ module "notification_image_republish" {
 module "cloud_cron" {
   source = "git::https://github.com/omsf/lambdacron.git"
 
-  aws_region        = var.aws_region
-  lambda_image_uri    = module.lambda_image_republish.lambda_image_uri
-  schedule_expression = var.schedule_expression
-  topic_name          = var.topic_name
-  fifo_topic          = var.fifo_topic
+  aws_region                  = var.aws_region
+  lambda_image_uri            = module.lambda_image_republish.lambda_image_uri
+  schedule_expression         = var.schedule_expression
+  topic_name                  = var.topic_name
+  fifo_topic                  = var.fifo_topic
   content_based_deduplication = var.content_based_deduplication
 
-  lambda_env    = local.lambda_env
-  timeout       = var.lambda_timeout
-  memory_size   = var.lambda_memory_size
-  lambda_name   = var.lambda_name
-  image_command = var.lambda_image_command
+  lambda_env      = local.lambda_env
+  timeout         = var.lambda_timeout
+  memory_size     = var.lambda_memory_size
+  lambda_name     = var.lambda_name
+  image_command   = var.lambda_image_command
   create_test_url = var.create_test_url
 
   tags = local.tags
@@ -86,11 +90,11 @@ module "email_notification" {
   count  = local.enable_email_notification ? 1 : 0
   source = "git::https://github.com/omsf/lambdacron.git//modules/email-notification"
 
-  sns_topic_arn     = module.cloud_cron.sns_topic_arn
-  result_types      = var.email_result_types
-  fifo_queue_name   = var.email_fifo_queue_name
-  lambda_image_uri  = module.notification_image_republish.lambda_image_uri
-  lambda_name       = var.email_lambda_name
+  sns_topic_arn    = module.cloud_cron.sns_topic_arn
+  result_types     = var.email_result_types
+  fifo_queue_name  = var.email_fifo_queue_name
+  lambda_image_uri = local.notification_lambda_image_uri
+  lambda_name      = var.email_lambda_name
 
   subject_template_file = local.email_subject_template_file
   text_template_file    = local.email_text_template_file
@@ -113,7 +117,7 @@ module "print_notification" {
   sns_topic_arn    = module.cloud_cron.sns_topic_arn
   result_types     = var.email_result_types
   fifo_queue_name  = "${trimsuffix(var.email_fifo_queue_name, ".fifo")}-print.fifo"
-  lambda_image_uri = module.notification_image_republish.lambda_image_uri
+  lambda_image_uri = local.notification_lambda_image_uri
   template_file    = local.email_text_template_file
 
   timeout     = var.email_timeout

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,8 +4,13 @@ output "lambda_republished_image_uri" {
 }
 
 output "notification_republished_image_uri" {
-  description = "Private ECR image URI for the republished notification image."
-  value       = module.notification_image_republish.lambda_image_uri
+  description = "Private ECR image URI for the republished notification image (null when notification_image_uri_override is used)."
+  value       = local.use_notification_image_override ? null : module.notification_image_republish[0].lambda_image_uri
+}
+
+output "notification_image_uri" {
+  description = "Notification image URI used by notification lambdas (republished image or notification_image_uri_override)."
+  value       = local.notification_lambda_image_uri
 }
 
 output "sns_topic_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,14 +35,17 @@ variable "lambda_env" {
 variable "eshgham_config_file" {
   description = "Path to the ESHGHAM workflows YAML file to load into ESHGHAM_WORKFLOWS_YAML."
   type        = string
-  default     = ""
 }
 
 variable "github_token" {
   description = "GitHub token to set as GITHUB_TOKEN for the scheduled Lambda."
   type        = string
-  default     = ""
   sensitive   = true
+
+  validation {
+    condition     = length(trimspace(var.github_token)) > 0
+    error_message = "github_token must be a non-empty token value."
+  }
 }
 
 variable "lambda_timeout" {
@@ -89,7 +92,7 @@ variable "lambda_public_tag" {
 variable "lambda_private_repository_name" {
   description = "Optional name for the private ECR repository that stores the republished ESHGHAM image."
   type        = string
-  default     = null
+  default     = "eshgham-local-deploy"
 }
 
 variable "lambda_enable_kms_encryption" {
@@ -119,7 +122,7 @@ variable "notification_public_tag" {
 variable "notification_private_repository_name" {
   description = "Optional name for the private ECR repository that stores the republished notification image."
   type        = string
-  default     = null
+  default     = "eshgham-notification-local"
 }
 
 variable "notification_enable_kms_encryption" {
@@ -143,7 +146,7 @@ variable "email_result_types" {
 variable "email_fifo_queue_name" {
   description = "Name for the FIFO SQS queue feeding the email notifier. Must end with .fifo."
   type        = string
-  default     = ""
+  default     = "eshgham-email.fifo"
 }
 
 variable "email_subject_template_file" {
@@ -185,7 +188,7 @@ variable "email_reply_to" {
 variable "email_lambda_name" {
   description = "Optional name for the email notification Lambda."
   type        = string
-  default     = null
+  default     = "eshgham-email-notifier"
 }
 
 variable "email_timeout" {

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,11 @@ variable "email_fifo_queue_name" {
   description = "Name for the FIFO SQS queue feeding the email notifier. Must end with .fifo."
   type        = string
   default     = "eshgham-email.fifo"
+
+  validation {
+    condition     = endswith(var.email_fifo_queue_name, ".fifo")
+    error_message = "email_fifo_queue_name must end with .fifo to be a valid FIFO SQS queue name."
+  }
 }
 
 variable "email_subject_template_file" {

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,17 @@ variable "notification_public_tag" {
   default     = "latest"
 }
 
+variable "notification_image_uri_override" {
+  description = "Optional full image URI for notification lambdas. When set, republish is skipped and this image is used directly."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.notification_image_uri_override == null || length(trimspace(var.notification_image_uri_override)) > 0
+    error_message = "notification_image_uri_override must be null or a non-empty image URI."
+  }
+}
+
 variable "notification_private_repository_name" {
   description = "Optional name for the private ECR repository that stores the republished notification image."
   type        = string


### PR DESCRIPTION
This makes a couple minor improvements that make deploying this a little nicer:

* Sets reasonable defaults for a number of names, etc. Also now forces GitHub token to be provided
* Allows override of notification lambda image.The idea is that, if you have a lot of these LambdaCron functions, it seems silly to *require* a duplicate copy of the image that contains our notifications code for each one. This gives an override to that.

Resolves #2