### PR TITLE
Refactor result types

### DIFF
--- a/lambda/docker/lambda_handler.py
+++ b/lambda/docker/lambda_handler.py
@@ -6,9 +6,22 @@ from typing import Any
 import github
 import yaml
 from lambdacron.lambda_task import CronLambdaTask
-from eshgham import Harness, Outputter, Status, get_token, make_json_ready
+from eshgham import Harness, Outputter, get_token, make_json_ready
 
 logging.basicConfig(level=logging.INFO)
+
+RESULT_TYPE_GROUPS: dict[str, tuple[str, ...]] = {
+    "ACTION_NEEDED": ("FAILED", "INACTIVATED"),
+    # Keep both spellings to tolerate upstream naming drift.
+    "WARNINGS": ("REENABLED", "REACTIVATED", "NO_SCHEDULED_RUNS"),
+    "ALL_ABNORMAL": (
+        "FAILED",
+        "INACTIVATED",
+        "REENABLED",
+        "REACTIVATED",
+        "NO_SCHEDULED_RUNS",
+    ),
+}
 
 
 class _SilentOutputter(Outputter):
@@ -25,6 +38,35 @@ def _load_workflow_config() -> dict[str, list[str]]:
     return workflow_dict
 
 
+def _collect_non_empty_workflows_by_status(
+    json_ready: dict[str, list[dict[str, Any]]], statuses: tuple[str, ...]
+) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for status in statuses:
+        workflows = json_ready.get(status) or []
+        if workflows:
+            grouped[status] = workflows
+    return grouped
+
+
+def _build_result_payload(
+    json_ready: dict[str, list[dict[str, Any]]],
+) -> dict[str, dict[str, Any]]:
+    result_payload: dict[str, dict[str, Any]] = {}
+
+    # Keep single-status result types so existing subscriptions continue working.
+    for status, workflows in json_ready.items():
+        if workflows:
+            result_payload[status] = {status: workflows}
+
+    for result_type, statuses in RESULT_TYPE_GROUPS.items():
+        grouped = _collect_non_empty_workflows_by_status(json_ready, statuses)
+        if grouped:
+            result_payload[result_type] = grouped
+
+    return result_payload
+
+
 class EshghamCronTask(CronLambdaTask):
     def _perform_task(self, event, context):
         logger = logging.getLogger(self.__class__.__name__)
@@ -37,11 +79,7 @@ class EshghamCronTask(CronLambdaTask):
             sorted_results = runner(gh, workflow_dict)
 
             json_ready = make_json_ready(sorted_results)
-            result_payload = {
-                status: {"workflows": workflows}
-                for status, workflows in json_ready.items()
-                if workflows
-            }
+            result_payload = _build_result_payload(json_ready)
             logger.info(
                 "eshgham_run_summary",
                 extra={"summary": json.dumps(result_payload)},
@@ -49,7 +87,12 @@ class EshghamCronTask(CronLambdaTask):
             return result_payload
         except Exception as exc:
             logger.exception("eshgham_run_exception")
-            return {"FAILED": {"workflows": [], "error": str(exc)}}
+            error_payload = {"FAILED": [], "error": str(exc)}
+            return {
+                "FAILED": dict(error_payload),
+                "ACTION_NEEDED": dict(error_payload),
+                "ALL_ABNORMAL": dict(error_payload),
+            }
 
 
 task = EshghamCronTask()

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ module "cloud_cron" {
   source = "git::https://github.com/omsf/lambdacron.git"
 
   aws_region        = var.aws_region
-  lambda_image_uri    = module.lambda_image_republish.lambda_image_uri
+  lambda_image_uri    = module.lambda_image_republish.lambda_image_uri_with_digest
   schedule_expression = var.schedule_expression
   topic_name          = var.topic_name
   fifo_topic          = var.fifo_topic
@@ -83,7 +83,7 @@ module "email_notification" {
   sns_topic_arn     = module.cloud_cron.sns_topic_arn
   result_types      = var.email_result_types
   fifo_queue_name   = var.email_fifo_queue_name
-  lambda_image_uri  = module.notification_image_republish.lambda_image_uri
+  lambda_image_uri  = module.notification_image_republish.lambda_image_uri_with_digest
   lambda_name       = var.email_lambda_name
 
   subject_template_file = var.email_subject_template_file
@@ -107,7 +107,7 @@ module "print_notification" {
   sns_topic_arn    = module.cloud_cron.sns_topic_arn
   result_types     = var.email_result_types
   fifo_queue_name  = "${trimsuffix(var.email_fifo_queue_name, ".fifo")}-print.fifo"
-  lambda_image_uri = module.notification_image_republish.lambda_image_uri
+  lambda_image_uri = module.notification_image_republish.lambda_image_uri_with_digest
   template_file    = var.email_text_template_file
 
   timeout     = var.email_timeout

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "lambda_republished_image_uri" {
   description = "Private ECR image URI for the republished ESHGHAM lambda image."
-  value       = module.lambda_image_republish.lambda_image_uri
+  value       = module.lambda_image_republish.lambda_image_uri_with_digest
 }
 
 output "notification_republished_image_uri" {

--- a/templates/email-body.html
+++ b/templates/email-body.html
@@ -1,16 +1,26 @@
 <html>
   <body>
     <h2>ESHGHAM workflow report: {{ result_type }}</h2>
-    {% if workflows %}
-    <p>Workflows ({{ workflows | length }}):</p>
+    {% if error is defined and error %}
+    <p><strong>Error:</strong> {{ error }}</p>
+    {% endif %}
+
+    {% set total_workflow_count = (FAILED | default([]) | length) + (INACTIVATED | default([]) | length) + (REENABLED | default([]) | length) + (REACTIVATED | default([]) | length) + (NO_SCHEDULED_RUNS | default([]) | length) + (OK | default([]) | length) %}
+    {% if total_workflow_count %}
+    <p>Workflows ({{ total_workflow_count }}):</p>
+    {% for status_name, status_workflows in [("FAILED", FAILED | default([])), ("INACTIVATED", INACTIVATED | default([])), ("REENABLED", REENABLED | default([])), ("REACTIVATED", REACTIVATED | default([])), ("NO_SCHEDULED_RUNS", NO_SCHEDULED_RUNS | default([])), ("OK", OK | default([]))] %}
+    {% if status_workflows %}
+    <h3>{{ status_name }} ({{ status_workflows | length }})</h3>
     <ul>
-      {% for workflow in workflows %}
+      {% for workflow in status_workflows %}
       <li>
         <strong>{{ workflow.repo }}</strong> :: {{ workflow.workflow_name }}<br />
         <a href="{{ workflow.url }}">{{ workflow.url }}</a>
       </li>
       {% endfor %}
     </ul>
+    {% endif %}
+    {% endfor %}
     {% else %}
     <p>No workflows reported for this status.</p>
     {% endif %}

--- a/templates/email-body.html
+++ b/templates/email-body.html
@@ -22,7 +22,7 @@
     {% endif %}
     {% endfor %}
     {% else %}
-    <p>No workflows reported for this status.</p>
+    <p>No workflows reported for this result type.</p>
     {% endif %}
   </body>
 </html>

--- a/templates/email-body.txt
+++ b/templates/email-body.txt
@@ -1,10 +1,22 @@
 ESHGHAM workflow report: {{ result_type }}
 
-{% if workflows %}
-Workflows ({{ workflows | length }}):
-{% for workflow in workflows -%}
+{% if error is defined and error %}
+Error: {{ error }}
+
+{% endif %}
+
+{% set total_workflow_count = (FAILED | default([]) | length) + (INACTIVATED | default([]) | length) + (REENABLED | default([]) | length) + (REACTIVATED | default([]) | length) + (NO_SCHEDULED_RUNS | default([]) | length) + (OK | default([]) | length) %}
+{% if total_workflow_count %}
+Workflows ({{ total_workflow_count }}):
+{% for status_name, status_workflows in [("FAILED", FAILED | default([])), ("INACTIVATED", INACTIVATED | default([])), ("REENABLED", REENABLED | default([])), ("REACTIVATED", REACTIVATED | default([])), ("NO_SCHEDULED_RUNS", NO_SCHEDULED_RUNS | default([])), ("OK", OK | default([]))] -%}
+{% if status_workflows %}
+
+{{ status_name }} ({{ status_workflows | length }}):
+{% for workflow in status_workflows -%}
 - {{ workflow.repo }} :: {{ workflow.workflow_name }}
   {{ workflow.url }}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% else %}
 No workflows reported for this status.

--- a/templates/email-body.txt
+++ b/templates/email-body.txt
@@ -19,5 +19,5 @@ Workflows ({{ total_workflow_count }}):
 {% endif %}
 {% endfor %}
 {% else %}
-No workflows reported for this status.
+No workflows reported for this result type.
 {% endif %}

--- a/variables.tf
+++ b/variables.tf
@@ -135,9 +135,9 @@ variable "notification_kms_key_arn" {
 }
 
 variable "email_result_types" {
-  description = "Result types to subscribe to; empty means all. Supports both base statuses (e.g. FAILED) and grouped categories (ACTION_NEEDED, WARNINGS, ALL_ABNORMAL)."
+  description = "Result types to subscribe to. Defaults to ACTION_NEEDED. Supports both base statuses (e.g. FAILED) and grouped categories (ACTION_NEEDED, WARNINGS, ALL_ABNORMAL)."
   type        = list(string)
-  default     = []
+  default     = ["ACTION_NEEDED"]
 }
 
 variable "email_fifo_queue_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "notification_image_uri_override" {
   default     = null
 
   validation {
-    condition     = var.notification_image_uri_override == null || length(trimspace(var.notification_image_uri_override)) > 0
+    condition     = try(length(trimspace(var.notification_image_uri_override)) > 0, var.notification_image_uri_override == null)
     error_message = "notification_image_uri_override must be null or a non-empty image URI."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,7 @@ variable "notification_kms_key_arn" {
 }
 
 variable "email_result_types" {
-  description = "Result types to subscribe to; empty means all."
+  description = "Result types to subscribe to; empty means all. Supports both base statuses (e.g. FAILED) and grouped categories (ACTION_NEEDED, WARNINGS, ALL_ABNORMAL)."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
Previously, we had lambdacron result types (as subscribed to by SQS queues) as the same as the result types from ESHGHAM (`OK`, `INACTIVATED`, `NO_SCHEDULED_RUNS`, `FAILED`, `REENABLED`). However, since we create one SNS message for each result type, this meant that if we subscribed to multiple, we would get multiple emails.

In this PR, I clean it up a bit so that we can subscribe to single lambdacron result types that correspond to multiple ESHGHAM result types. My guess on the ones that people would usually want to subscribe to, and see grouped in one email:


* **ACTION_NEEDED**: ["FAILED", "INACTIVATED"],
* **WARNINGS**: ["REENABLED", "NO_SCHEDULED_RUNS",
* **ALL_ABNORMAL**: ["FAILED", "INACTIVATED", "REENABLED", "NO_SCHEDULED_RUNS"]

(Personally, I'm subscribed to ACTION_NEEDED for my stuff).

This also provides a way to send execution errors to the anyone who would receive FAILED notifications (FAILED, ACTION_NEEDED, ALL_ABNORMAL).

Resolves #3.