### PR TITLE
`bootstrap-deploy-repo` module

### DIFF
--- a/bootstrap-deploy-repo/README.md
+++ b/bootstrap-deploy-repo/README.md
@@ -1,0 +1,26 @@
+# bootstrap-deploy-repo
+
+Reusable deployment-bootstrap module for ESHGHAM repositories.
+
+This module creates the GitHub OIDC deploy role and manages required GitHub Actions secrets:
+
+- `AWS_DEPLOY_ROLE_ARN`
+- `TF_VAR_gh_token`
+
+Extension inputs are available for reuse in other roots:
+
+- `extra_permission_sets`
+- `additional_policy_arns`
+- `allowed_resource_name_prefixes`
+- `github_actions_secrets`
+
+Backend S3 + DynamoDB policy attachment and backend secrets (`TF_STATE_BUCKET`, `TF_STATE_TABLE`) are intentionally not part of this module. Add them in a backend-specific module at the calling root.
+
+Deployer permissions are prefix-scoped; default `allowed_resource_name_prefixes = ["eshgham"]`. Add additional prefixes when your deployment manages resources outside the default naming family.
+
+Useful defaults in this module:
+
+- `role_name = "eshgham-cron-deployer"`
+- `github_ref = "refs/heads/main"`
+- `github_workflow_filename = "deploy.yaml"`
+- `github_oidc_provider_arn = null` (auto-resolves to the current account OIDC provider ARN)

--- a/bootstrap-deploy-repo/README.md
+++ b/bootstrap-deploy-repo/README.md
@@ -20,7 +20,7 @@ Deployer permissions are prefix-scoped; default `allowed_resource_name_prefixes 
 
 Useful defaults in this module:
 
-- `role_name = "eshgham-cron-deployer"`
+- `role_name = "eshgham-cron-github-deployer"`
 - `github_ref = "refs/heads/main"`
 - `github_workflow_filename = "deploy.yaml"`
 - `github_oidc_provider_arn = null` (auto-resolves to the current account OIDC provider ARN)

--- a/bootstrap-deploy-repo/main.tf
+++ b/bootstrap-deploy-repo/main.tf
@@ -1,6 +1,7 @@
 locals {
-  default_github_actions_secrets = {
-    TF_VAR_gh_token = var.gh_token
+  required_github_actions_secrets = {
+    TF_VAR_gh_token     = var.gh_token
+    AWS_DEPLOY_ROLE_ARN = module.workflow_oidc_role.role_arn
   }
   default_permission_sets = toset([])
 
@@ -19,14 +20,11 @@ locals {
   github_repository_name   = local.github_repository_parts[1]
   github_subjects          = ["repo:${var.github_repository}:ref:${var.github_ref}"]
   github_job_workflow_refs = ["${var.github_repository}/.github/workflows/${var.github_workflow_filename}@${var.github_ref}"]
-  github_actions_secrets = merge(
-    local.default_github_actions_secrets,
+  managed_github_actions_secrets = merge(
     var.github_actions_secrets,
-    {
-      AWS_DEPLOY_ROLE_ARN = module.workflow_oidc_role.role_arn
-    }
+    local.required_github_actions_secrets
   )
-  github_actions_secret_keys = toset(keys(nonsensitive(local.github_actions_secrets)))
+  managed_github_actions_secret_keys = toset(keys(nonsensitive(local.managed_github_actions_secrets)))
   github_oidc_provider_arn = coalesce(
     var.github_oidc_provider_arn,
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
@@ -62,10 +60,10 @@ module "workflow_oidc_role" {
   tags                           = var.tags
 }
 
-resource "github_actions_secret" "user_defined" {
-  for_each = local.github_actions_secret_keys
+resource "github_actions_secret" "managed" {
+  for_each = local.managed_github_actions_secret_keys
 
   repository      = local.github_repository_name
   secret_name     = each.value
-  plaintext_value = local.github_actions_secrets[each.value]
+  plaintext_value = local.managed_github_actions_secrets[each.value]
 }

--- a/bootstrap-deploy-repo/main.tf
+++ b/bootstrap-deploy-repo/main.tf
@@ -1,0 +1,71 @@
+locals {
+  default_github_actions_secrets = {
+    TF_VAR_gh_token = var.gh_token
+  }
+  default_permission_sets = toset([])
+
+  required_permission_sets = toset([
+    "lambda-image-republish",
+    "email-notification",
+    "print-notification",
+    "root",
+  ])
+  permission_sets = setunion(
+    local.required_permission_sets,
+    local.default_permission_sets,
+    var.extra_permission_sets
+  )
+  github_repository_parts  = split("/", var.github_repository)
+  github_repository_name   = local.github_repository_parts[1]
+  github_subjects          = ["repo:${var.github_repository}:ref:${var.github_ref}"]
+  github_job_workflow_refs = ["${var.github_repository}/.github/workflows/${var.github_workflow_filename}@${var.github_ref}"]
+  github_actions_secrets = merge(
+    local.default_github_actions_secrets,
+    var.github_actions_secrets,
+    {
+      AWS_DEPLOY_ROLE_ARN = module.workflow_oidc_role.role_arn
+    }
+  )
+  github_actions_secret_keys = toset(keys(nonsensitive(local.github_actions_secrets)))
+  github_oidc_provider_arn = coalesce(
+    var.github_oidc_provider_arn,
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+  )
+}
+
+data "aws_caller_identity" "current" {}
+
+data "github_repository" "provider_context" {
+  name = local.github_repository_name
+}
+
+check "github_provider_owner_matches_repository_owner" {
+  assert {
+    condition     = data.github_repository.provider_context.full_name == var.github_repository
+    error_message = "GitHub provider owner mismatch: expected \"${var.github_repository}\" from repository name \"${local.github_repository_name}\", but provider resolved \"${data.github_repository.provider_context.full_name}\". Configure provider \"github\" with owner = \"${local.github_repository_parts[0]}\"."
+  }
+}
+
+module "workflow_oidc_role" {
+  source = "git::https://github.com/omsf/lambdacron.git//modules/github-deployer-role"
+
+  role_name                      = var.role_name
+  role_description               = var.role_description
+  max_session_duration           = var.max_session_duration
+  github_oidc_provider_arn       = local.github_oidc_provider_arn
+  github_audience                = var.github_audience
+  github_subjects                = local.github_subjects
+  github_job_workflow_refs       = local.github_job_workflow_refs
+  permission_sets                = local.permission_sets
+  allowed_resource_name_prefixes = var.allowed_resource_name_prefixes
+  additional_policy_arns         = var.additional_policy_arns
+  tags                           = var.tags
+}
+
+resource "github_actions_secret" "user_defined" {
+  for_each = local.github_actions_secret_keys
+
+  repository      = local.github_repository_name
+  secret_name     = each.value
+  plaintext_value = local.github_actions_secrets[each.value]
+}

--- a/bootstrap-deploy-repo/outputs.tf
+++ b/bootstrap-deploy-repo/outputs.tf
@@ -1,0 +1,24 @@
+output "role_arn" {
+  description = "ARN of the GitHub deployer role."
+  value       = module.workflow_oidc_role.role_arn
+}
+
+output "role_name" {
+  description = "Name of the GitHub deployer role."
+  value       = module.workflow_oidc_role.role_name
+}
+
+output "selected_permission_sets" {
+  description = "Permission sets attached to this role."
+  value       = module.workflow_oidc_role.selected_permission_sets
+}
+
+output "permission_set_policy_arns" {
+  description = "Managed policy ARNs generated for selected permission sets."
+  value       = module.workflow_oidc_role.permission_set_policy_arns
+}
+
+output "available_permission_sets" {
+  description = "All permission sets available from the source module."
+  value       = module.workflow_oidc_role.available_permission_sets
+}

--- a/bootstrap-deploy-repo/variables.tf
+++ b/bootstrap-deploy-repo/variables.tf
@@ -1,0 +1,104 @@
+variable "role_name" {
+  description = "Name for the GitHub deployer IAM role."
+  type        = string
+  default     = "eshgham-cron-github-deployer"
+}
+
+variable "role_description" {
+  description = "Description for the GitHub deployer IAM role."
+  type        = string
+  default     = "Role assumed by GitHub Actions to deploy ESHGHAM-cron modules."
+}
+
+variable "max_session_duration" {
+  description = "Maximum assumed-role session duration in seconds."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds."
+  }
+}
+
+variable "github_oidc_provider_arn" {
+  description = "ARN for the IAM OIDC provider backing token.actions.githubusercontent.com."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "github_repository" {
+  description = "GitHub repository in owner/repo form used for OIDC claims and Actions secret management."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[^/]+/[^/]+$", var.github_repository))
+    error_message = "github_repository must be in owner/repo format."
+  }
+}
+
+variable "github_ref" {
+  description = "Git ref that may assume the deploy role (for example refs/heads/main)."
+  type        = string
+  default     = "refs/heads/main"
+
+  validation {
+    condition     = startswith(var.github_ref, "refs/")
+    error_message = "github_ref must start with refs/."
+  }
+}
+
+variable "github_workflow_filename" {
+  description = "Workflow filename under .github/workflows/ that may assume the deploy role."
+  type        = string
+  default     = "deploy.yaml"
+
+  validation {
+    condition     = !strcontains(var.github_workflow_filename, "/")
+    error_message = "github_workflow_filename must be a file name, not a path."
+  }
+}
+
+variable "github_audience" {
+  description = "OIDC audience expected in GitHub-issued tokens."
+  type        = string
+  default     = "sts.amazonaws.com"
+}
+
+variable "gh_token" {
+  description = "GitHub token for ESHGHAM runs. Stored as TF_VAR_gh_token in GitHub Actions secrets."
+  type        = string
+  sensitive   = true
+}
+
+variable "github_actions_secrets" {
+  description = "Sensitive map of additional GitHub Actions secrets to create, keyed by secret name."
+  type        = map(string)
+  sensitive   = true
+  default     = {}
+}
+
+variable "extra_permission_sets" {
+  description = "Optional extra permission sets to union with required ESHGHAM permission sets."
+  type        = set(string)
+  default     = []
+}
+
+variable "allowed_resource_name_prefixes" {
+  description = "Allowed resource-name prefixes for deployer-managed infrastructure resources."
+  type        = set(string)
+  default     = ["eshgham"]
+}
+
+variable "additional_policy_arns" {
+  description = "Additional pre-existing managed policy ARNs to attach to the role."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags applied to created IAM resources."
+  type        = map(string)
+  default     = {}
+}

--- a/bootstrap-deploy-repo/versions.tf
+++ b/bootstrap-deploy-repo/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    github = {
+      source = "integrations/github"
+    }
+  }
+}

--- a/bootstrap-deploy-repo/versions.tf
+++ b/bootstrap-deploy-repo/versions.tf
@@ -3,10 +3,12 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
     github = {
-      source = "integrations/github"
+      source  = "integrations/github"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
This adds a Terraform module, `bootstrap-deploy-repo`, that creates infrastructure related to deploying eshgham-cron infrastructure via a GitHub Actions Workflow. This is primarily a role with appropriate permissions, which can be assumed by a workflow, plus a GitHub Actions secret to store the GitHub token needed to run ESHGHAM.