### PR TITLE
Use uri_with_digest for notification image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   enable_email_notification           = length(var.email_recipients) > 0
   notification_image_uri_override     = var.notification_image_uri_override == null ? null : trimspace(var.notification_image_uri_override)
   use_notification_image_override     = local.notification_image_uri_override != null
-  notification_lambda_image_uri       = local.use_notification_image_override ? local.notification_image_uri_override : module.notification_image_republish[0].lambda_image_uri
+  notification_lambda_image_uri       = local.use_notification_image_override ? local.notification_image_uri_override : module.notification_image_republish[0].lambda_image_uri_with_digest
   default_email_subject_template_file = "${path.module}/templates/email-subject.txt"
   default_email_text_template_file    = "${path.module}/templates/email-body.txt"
   default_email_html_template_file    = "${path.module}/templates/email-body.html"

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,12 +4,12 @@ output "lambda_republished_image_uri" {
 }
 
 output "notification_republished_image_uri" {
-  description = "Private ECR image URI for the republished notification image (null when notification_image_uri_override is used)."
-  value       = local.use_notification_image_override ? null : module.notification_image_republish[0].lambda_image_uri
+  description = "Private ECR image URI with digest for the republished notification image (null when notification_image_uri_override is used)."
+  value       = local.use_notification_image_override ? null : module.notification_image_republish[0].lambda_image_uri_with_digest
 }
 
 output "notification_image_uri" {
-  description = "Notification image URI used by notification lambdas (republished image or notification_image_uri_override)."
+  description = "Notification image URI used by notification lambdas (republished image with digest or notification_image_uri_override)."
   value       = local.notification_lambda_image_uri
 }
 


### PR DESCRIPTION
This may fix some problems we occasionally have in deployment, where the lambda tries to deploy and can't find the source image for the lambda, leading to errors like this:

> │ Error: creating Lambda Function (eshgham-print-notification): operation error Lambda: CreateFunction, https response error StatusCode: 400, RequestID: 79adf23c-f140-47ab-b5dd-5aa28f4296a5, InvalidParameterValueException: Source image 123456789012.dkr.ecr.us-east-1.amazonaws.com/eshgham-notification-local:latest does not exist. Provide a valid source image.